### PR TITLE
Add fallback for poetry.update and poetry.update_to_latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ We follow [Semantic Versions](https://semver.org/).
 ## unreleased
 
 - Improve `pre-commit.run-hooks` command with `params`
+- Add fallback for `poetry.update` and `poetry.update_to_latest`
 
 ## 0.9.1
 

--- a/README.md
+++ b/README.md
@@ -846,10 +846,15 @@ Update dependencies with respect to
 [version constraints](https://python-poetry.org/docs/dependency-specification/)
 using [poetry up plugin](https://github.com/MousaZeidBaker/poetry-plugin-up).
 
+Fallbacks to `poetry update` in case of an error.
+
 #### poetry.update-to-latest
 
 Update dependencies to latest versions using
 [poetry up plugin](https://github.com/MousaZeidBaker/poetry-plugin-up).
+
+By default fallbacks to [`update`](#poetryupdate) task in case of an error.
+Use `--no-fallback` to stop on error.
 
 ### pip
 


### PR DESCRIPTION
Poetry up plugin fails if some update are incompatible with each other, for example arrow and gitlint