### PR TITLE
Fix git blame copy script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ We follow [Semantic Versions](https://semver.org/).
 
 ## unreleased
 
+Fix `git.blame-copy` in case if merge conflict between files occurs.
+
 ## 1.0.0
 
 First stable release

--- a/saritasa_invocations/git.py
+++ b/saritasa_invocations/git.py
@@ -200,6 +200,7 @@ def _merge_commits(
         f"git merge {' '.join(commits)} -m '{message}'",
         warn=True,
     )
+    # create commit in case if merge conflict occurs
     context.run(
         f"git commit --no-verify -a -n -m '{message}'",
     )

--- a/saritasa_invocations/git.py
+++ b/saritasa_invocations/git.py
@@ -196,7 +196,13 @@ def _merge_commits(
     message: str,
 ) -> None:
     """Merge passed commits."""
-    context.run(f"git merge {' '.join(commits)} -m '{message}'")
+    context.run(
+        f"git merge {' '.join(commits)} -m '{message}'",
+        warn=True,
+    )
+    context.run(
+        f"git commit --no-verify -a -n -m '{message}'",
+    )
 
 
 def _move_file(


### PR DESCRIPTION
There're cases when merge conflict can occur on `merge` step of `git.blame-copy`. It can be fixed by adding additional `commit` command after merge.