### PR TITLE
Fix `git.blame-copy` merging without conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ We follow [Semantic Versions](https://semver.org/).
 
 ## unreleased
 
+- Fix `git.blame-copy` merging without conflicts
+
 ## 1.3.0
 
 - Add params for `system.chown`(`owner` and `path`)

--- a/saritasa_invocations/git.py
+++ b/saritasa_invocations/git.py
@@ -237,6 +237,7 @@ def _merge_commits(
     # create commit in case if merge conflict occurs
     context.run(
         f"git commit --no-verify -a -n -m '{message}'",
+        warn=True,
     )
 
 


### PR DESCRIPTION
There was a problem with git.blame-copy here. When merge happened without conflicts, the script would stop working.

![image](https://github.com/user-attachments/assets/300812f1-2760-4621-82b9-f8d38eda6c28)
