### PR TITLE
Extend dump options for db configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ We follow [Semantic Versions](https://semver.org/).
 - Improve generated name for k8s db dumps.
 Also add `--add-date-to-generated-filename` option to add timestamp for db
 dumps from k8s(including commands for django and alembic).
+- Add new options for `DBSettings` and `K8SDBSettings`
+  - `dump_additional_params` additional params for dump command (Default: ``)
+  - `dump_no_owner` add `--no-owner` to dump command (Default: `True`)
+  - `dump_include_table` add `--table={dump_include_table}` to dump command (Default: ``)
+  - `dump_exclude_table` add `--exclude-table={dump_exclude_table}` to dump command (Default: ``)
+  - `dump_exclude_table_data` add `--exclude-table-data={dump_exclude_table_data}` to dump command (Default: ``)
+  - `dump_exclude_extension` add `--exclude-extension={dump_exclude_extension}` to dump command (Default: ``)
+
 
 ## 1.4.0
 

--- a/README.md
+++ b/README.md
@@ -794,7 +794,12 @@ Settings:
 
 * `dump_command` template for dump command (Default located in `_config.pp > dbSettings`)
 * `dump_filename` filename for dump (Default: `local_db_dump`)
-* `dump_additional_params` additional params for dump command (Default: `--no-owner`)
+* `dump_additional_params` additional params for dump command (Default: ``)
+* `dump_no_owner` add `--no-owner` to dump command (Default: `True`)
+* `dump_include_table` add `--table={dump_include_table}` to dump command (Default: ``)
+* `dump_exclude_table` add `--exclude-table={dump_exclude_table}` to dump command (Default: ``)
+* `dump_exclude_table_data` add `--exclude-table-data={dump_exclude_table_data}` to dump command (Default: ``)
+* `dump_exclude_extension` add `--exclude-extension={dump_exclude_extension}` to dump command (Default: ``)
 
 ### k8s
 
@@ -908,7 +913,12 @@ Settings:
 * `dump_filename` default dump filename (Default: Name of project from `project_name` plus `_db_dump`)
 * `dump_command` dump command template (Default located in `_config.pp > K8SDBSettings`)
 * `dump_dir` folder where to put dump file (Default: `tmp`)
-* `dump_additional_params` additional dump commands (Default: `--no-owner`)
+* `dump_additional_params` additional params for dump command (Default: ``)
+* `dump_no_owner` add `--no-owner` to dump command (Default: `True`)
+* `dump_include_table` add `--table={dump_include_table}` to dump command (Default: ``)
+* `dump_exclude_table` add `--exclude-table={dump_exclude_table}` to dump command (Default: ``)
+* `dump_exclude_table_data` add `--exclude-table-data={dump_exclude_table_data}` to dump command (Default: ``)
+* `dump_exclude_extension` add `--exclude-extension={dump_exclude_extension}` to dump command (Default: ``)
 
 #### db-k8s.get-dump
 

--- a/saritasa_invocations/_config.py
+++ b/saritasa_invocations/_config.py
@@ -209,7 +209,12 @@ class DBSettings:
         "--username={username} "
         "--file={file}"
     )
-    dump_additional_params: str = "--no-owner"
+    dump_additional_params: str = ""
+    dump_no_owner: bool = True
+    dump_include_table: str = ""
+    dump_exclude_table: str = ""
+    dump_exclude_table_data: str = ""
+    dump_exclude_extension: str = ""
 
 
 # This mapping should not be filled manually. You just need create an instance
@@ -255,7 +260,12 @@ class K8SDBSettings:
         "--username={username} "
         "--file {file}"
     )
-    dump_additional_params: str = "--no-owner"
+    dump_additional_params: str = ""
+    dump_no_owner: bool = True
+    dump_include_table: str = ""
+    dump_exclude_table: str = ""
+    dump_exclude_table_data: str = ""
+    dump_exclude_extension: str = ""
 
 
 @dataclasses.dataclass(frozen=True)

--- a/saritasa_invocations/db.py
+++ b/saritasa_invocations/db.py
@@ -50,6 +50,29 @@ def backup_local_db(
     """Back up local db."""
     config = _config.Config.from_context(context)
     printing.print_success("Creating backup of local db.")
+    additional_params_list = [
+        config.db.dump_additional_params,
+    ]
+    if config.db.dump_no_owner:
+        additional_params_list.append(
+            "--no-owner",
+        )
+    if config.db.dump_include_table:
+        additional_params_list.append(
+            f"--table={config.db.dump_include_table}",
+        )
+    if config.db.dump_exclude_table:
+        additional_params_list.append(
+            f"--exclude-table={config.db.dump_exclude_table}",
+        )
+    if config.db.dump_exclude_table_data:
+        additional_params_list.append(
+            f"--exclude-table-data={config.db.dump_exclude_table_data}",
+        )
+    if config.db.dump_exclude_extension:
+        additional_params_list.append(
+            f"--exclude-extension={config.db.dump_exclude_extension}",
+        )
     context.run(
         config.db.dump_command.format(
             dbname=dbname,
@@ -58,7 +81,7 @@ def backup_local_db(
             username=username,
             file=file or config.db.dump_filename,
             additional_params=additional_params
-            or config.db.dump_additional_params,
+            or " ".join(additional_params_list),
         ),
         watchers=(
             invoke.Responder(

--- a/saritasa_invocations/db_k8s.py
+++ b/saritasa_invocations/db_k8s.py
@@ -105,13 +105,37 @@ def _generate_dump_command(
         add_date_to_generated_filename=add_date_to_generated_filename,
         file=file,
     )
+    additional_params_list = [
+        config.dump_additional_params,
+    ]
+    if config.dump_no_owner:
+        additional_params_list.append(
+            "--no-owner",
+        )
+    if config.dump_include_table:
+        additional_params_list.append(
+            f"--table={config.dump_include_table}",
+        )
+    if config.dump_exclude_table:
+        additional_params_list.append(
+            f"--exclude-table={config.dump_exclude_table}",
+        )
+    if config.dump_exclude_table_data:
+        additional_params_list.append(
+            f"--exclude-table-data={config.dump_exclude_table_data}",
+        )
+    if config.dump_exclude_extension:
+        additional_params_list.append(
+            f"--exclude-extension={config.dump_exclude_extension}",
+        )
     return config.dump_command.format(
         dbname=dbname,
         host=host,
         port=port,
         username=username,
         file=f"{config.dump_dir}/{filename}",
-        additional_params=additional_params or config.dump_additional_params,
+        additional_params=additional_params
+        or " ".join(additional_params_list),
     )
 
 


### PR DESCRIPTION
- Add new options for `DBSettings` and `K8SDBSettings`
  - `dump_additional_params` additional params for dump command (Default: ``)
  - `dump_no_owner` add `--no-owner` to dump command (Default: `True`)
  - `dump_include_table` add `--table={dump_include_table}` to dump command (Default: ``)
  - `dump_exclude_table` add `--exclude-table={dump_exclude_table}` to dump command (Default: ``)
  - `dump_exclude_table_data` add `--exclude-table-data={dump_exclude_table_data}` to dump command (Default: ``)
  - `dump_exclude_extension` add `--exclude-extension={dump_exclude_extension}` to dump command (Default: ``)