### PR TITLE
Run celery in foreground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ We follow [Semantic Versions](https://semver.org/).
 ## Unreleased
 
 - Fix default `docker_service` for `PythonSettings`
+- Run celery docker container in foreground by default
 
 ## 1.5.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ To install them you would need to run `install` command:
 poetry install
 ```
 
-To activate your `virtualenv` run `poetry shell`.
+To activate your `virtualenv` run `eval $(poetry env activate)`.
 
 ## Style checks
 
@@ -51,4 +51,4 @@ Before submitting your code please do the following steps:
 1. Add any changes you want
 2. Edit documentation if you have changed something significant
 3. Update `CHANGELOG.md` with a quick summary of your changes
-5. Run `pre-commit` to ensure that style is correct
+4. Run `pre-commit` to ensure that style is correct

--- a/saritasa_invocations/celery.py
+++ b/saritasa_invocations/celery.py
@@ -6,7 +6,7 @@ from . import _config, docker, python
 @invoke.task
 def run(
     context: invoke.Context,
-    detach: bool = True,
+    detach: bool = False,
 ) -> None:
     """Start celery worker."""
     config = _config.Config.from_context(context).celery


### PR DESCRIPTION
Now `inv celery.run` will work similar for local/docker envs - it will start foreground process and display logs