### PR TITLE
Rework dump filename generation for `db_k8s`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ We follow [Semantic Versions](https://semver.org/).
 - Run celery docker container in foreground by default
 - Fix k8s login and adjust `K8SSettings`
   - Now `cluster` is not required while `context` is required
+- Rework dump filename generation for `db_k8s`. Now we have `dump_filename_template`
+with which you can define template for name. Default: `{project_name}-{env}-{timestamp:%Y-%m-%d}-db-dump.{extension}`. `--add-date-to-generated-filename` option is removed.
 
 ## 1.5.0
 

--- a/README.md
+++ b/README.md
@@ -912,7 +912,7 @@ Settings:
 * `pod_namespace` db namespace (**REQUIRED**)
 * `pod_selector` pod selector for db (**REQUIRED**)
 * `get_pod_name_command` template for fetching db pod (Default located in `_config.pp > K8SdbSettings`)
-* `dump_filename` default dump filename (Default: Name of project from `project_name` plus `_db_dump`)
+* `dump_filename_template` template for dump filename (Default: `{project_name}-{env}-{timestamp:%Y-%m-%d}-db-dump.{extension}`)
 * `dump_command` dump command template (Default located in `_config.pp > K8SDBSettings`)
 * `dump_dir` folder where to put dump file (Default: `tmp`)
 * `dump_additional_params` additional params for dump command (Default: ``)
@@ -931,7 +931,7 @@ Settings:
 * `pod_namespace` db namespace (**REQUIRED**)
 * `pod_selector` pod selector for db (**REQUIRED**)
 * `get_pod_name_command` template for fetching db pod (Default located in `_config.pp > K8SDBSettings`)
-* `dump_filename` default dump filename (Default: Name of project from `project_name` plus `_db_dump`)
+* `dump_filename_template` template for dump filename (Default: `{project_name}-{env}-{timestamp:%Y-%m-%d}-db-dump.{extension}`)
 
 ### cruft
 

--- a/saritasa_invocations/_config.py
+++ b/saritasa_invocations/_config.py
@@ -198,7 +198,7 @@ class DBSettings:
         "--username={username} "
         "--file={file}"
     )
-    dump_filename: str = "local_db_dump.sql"
+    dump_filename: str = "local-db-dump.sql"
     load_additional_params: str = "--quiet"
     dump_command: str = (
         "pg_dump "
@@ -240,7 +240,9 @@ class K8SDBSettings:
 
     namespace: str
     pod_selector: str
-    dump_filename: str = ""
+    dump_filename_template: str = (
+        "{project_name}-{env}-{timestamp:%Y-%m-%d}-db-dump.{extension}"
+    )
     password_pattern: str = "Password: "  # noqa: S105
     get_pod_name_command: str = (
         "kubectl get pods --namespace {db_pod_namespace} "

--- a/saritasa_invocations/alembic.py
+++ b/saritasa_invocations/alembic.py
@@ -225,20 +225,17 @@ def backup_local_db(
 def backup_remote_db(
     context: invoke.Context,
     file: str = "",
-    add_date_to_generated_filename: bool = False,
 ) -> str:
     """Make dump of remote db and download it."""
     settings = _load_remote_env_db_settings(context)
     db_k8s.create_dump(
         context,
         file=file,
-        add_date_to_generated_filename=add_date_to_generated_filename,
         **settings,
     )
     return db_k8s.get_dump(
         context,
         file=file,
-        add_date_to_generated_filename=add_date_to_generated_filename,
     )
 
 

--- a/saritasa_invocations/django.py
+++ b/saritasa_invocations/django.py
@@ -321,20 +321,17 @@ def backup_local_db(
 def backup_remote_db(
     context: invoke.Context,
     file: str = "",
-    add_date_to_generated_filename: bool = False,
 ) -> str:
     """Make dump of remote db and download it."""
     settings = load_django_remote_env_db_settings(context)
     db_k8s.create_dump(
         context,
         file=file,
-        add_date_to_generated_filename=add_date_to_generated_filename,
         **settings,
     )
     return db_k8s.get_dump(
         context,
         file=file,
-        add_date_to_generated_filename=add_date_to_generated_filename,
     )
 
 


### PR DESCRIPTION
Rework dump filename generation for `db_k8s`.
Now we have `dump_filename_template`with which you can define template for name.
Default: `{project_name}-{env}-{timestamp:%Y-%m-%d}-db-dump.{extension}`. `--add-date-to-generated-filename` option is removed.